### PR TITLE
Always Run Intake

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -207,7 +207,7 @@ public class Robot extends CommandRobot {
 
     public CommandBase intakeGamePiece() {
         return rumbleOn().andThen(led.intakeSpinning(), intake.grab(), rumbleOff(),
-                led.grabbedPiece());
+                led.grabbedPiece()).finallyDo(intake::holdGamePiece);
     }
 
     @Override

--- a/src/main/java/frc/robot/subsystems/Intake.java
+++ b/src/main/java/frc/robot/subsystems/Intake.java
@@ -75,7 +75,7 @@ public class Intake extends LoggedSubsystem<IntakeData, IntakeData.Map> {
     }
 
     public CommandBase grab() {
-        return spinIn().andThen(new FunctionalWaitCommand(() -> 0.75), runOnce(() -> {
+        return spinIn().andThen(new FunctionalWaitCommand(() -> 0.75).finallyDo((interupt) -> {
             getData().motorSetPoint = 0.05;
         }));
     }

--- a/src/main/java/frc/robot/subsystems/Intake.java
+++ b/src/main/java/frc/robot/subsystems/Intake.java
@@ -74,10 +74,12 @@ public class Intake extends LoggedSubsystem<IntakeData, IntakeData.Map> {
                 }).runsUntil(currentPersistenceCheck);
     }
 
+    public void holdGamePiece(boolean interrupted) {
+        getData().motorSetPoint = 0.05;
+    }
+
     public CommandBase grab() {
-        return spinIn().andThen(new FunctionalWaitCommand(() -> 0.75).finallyDo((interupt) -> {
-            getData().motorSetPoint = 0.05;
-        }));
+        return spinIn().andThen(new FunctionalWaitCommand(() -> 0.75).finallyDo(this::holdGamePiece));
     }
 
     // Releases game piece Cube


### PR DESCRIPTION
Fixed the intake so that whenever the grab command is used, it makes sure the motor is always set. Before, another button would be pressed and would interrupt the command so it didn't completely finish. These updates are to make sure that even if that happens, the entire command is run.