### PR TITLE
Square Autos: Pathing + Drive Relative

### DIFF
--- a/.pathplanner/settings.json
+++ b/.pathplanner/settings.json
@@ -1,0 +1,7 @@
+{
+  "robotWidth": 0.81,
+  "robotLength": 0.813,
+  "holonomicMode": false,
+  "generateJSON": false,
+  "generateCSV": false
+}

--- a/src/main/deploy/pathplanner/OnePiece.path
+++ b/src/main/deploy/pathplanner/OnePiece.path
@@ -1,0 +1,102 @@
+{
+  "waypoints": [
+    {
+      "anchorPoint": {
+        "x": 1.842127764840828,
+        "y": 0.4969176485710434
+      },
+      "prevControl": null,
+      "nextControl": {
+        "x": 3.0724879405938506,
+        "y": 0.51874171632516
+      },
+      "holonomicAngle": 0,
+      "isReversal": false,
+      "velOverride": null,
+      "isLocked": false,
+      "isStopPoint": false,
+      "stopEvent": {
+        "names": [],
+        "executionBehavior": "parallel",
+        "waitBehavior": "none",
+        "waitTime": 0
+      }
+    },
+    {
+      "anchorPoint": {
+        "x": 6.267278996480775,
+        "y": 0.7574310961610193
+      },
+      "prevControl": {
+        "x": 5.617330615422255,
+        "y": 0.48088414513154515
+      },
+      "nextControl": {
+        "x": 6.867805170067302,
+        "y": 1.0129493606242366
+      },
+      "holonomicAngle": 0,
+      "isReversal": false,
+      "velOverride": null,
+      "isLocked": false,
+      "isStopPoint": true,
+      "stopEvent": {
+        "names": [],
+        "executionBehavior": "sequential",
+        "waitBehavior": "none",
+        "waitTime": 0
+      }
+    },
+    {
+      "anchorPoint": {
+        "x": 5.738219997064064,
+        "y": 2.696384664460061
+      },
+      "prevControl": {
+        "x": 5.8310935966092785,
+        "y": 1.997496950287101
+      },
+      "nextControl": {
+        "x": 5.430327484586774,
+        "y": 5.013321827549815
+      },
+      "holonomicAngle": 0,
+      "isReversal": false,
+      "velOverride": null,
+      "isLocked": false,
+      "isStopPoint": false,
+      "stopEvent": {
+        "names": [],
+        "executionBehavior": "parallel",
+        "waitBehavior": "none",
+        "waitTime": 0
+      }
+    },
+    {
+      "anchorPoint": {
+        "x": 1.8685547248362973,
+        "y": 4.863732277266336
+      },
+      "prevControl": {
+        "x": 5.148397787320594,
+        "y": 4.892184539894215
+      },
+      "nextControl": null,
+      "holonomicAngle": 0,
+      "isReversal": false,
+      "velOverride": null,
+      "isLocked": false,
+      "isStopPoint": false,
+      "stopEvent": {
+        "names": [],
+        "executionBehavior": "parallel",
+        "waitBehavior": "none",
+        "waitTime": 0
+      }
+    }
+  ],
+  "maxVelocity": 5.0,
+  "maxAcceleration": 4.0,
+  "isReversed": null,
+  "markers": []
+}

--- a/src/main/java/frc/robot/ArmPresets.java
+++ b/src/main/java/frc/robot/ArmPresets.java
@@ -26,7 +26,7 @@ public enum ArmPresets {
 
     ARM_STOWED(1, 2, 1),
 
-    CUBE_PICKUP(4, 18, 18),
+    CUBE_PICKUP(4, 22, 22),
 
     CONE_PICKUP(8.9, 33, 33);
 

--- a/src/main/java/frc/robot/Auto.java
+++ b/src/main/java/frc/robot/Auto.java
@@ -268,12 +268,14 @@ public class Auto {
 
                 AutoPath.KNOCKOUT_AUTO_POS1.getPath(drive),
                 AutoPath.KNOCKOUT_AUTO_POS2.getPath(drive),
-                AutoPath.KNOCKOUT_AUTO_POS3.getPath(drive),
+                parallel(AutoPath.KNOCKOUT_AUTO_POS3.getPath(drive), pickUpCube()),
                 AutoPath.KNOCKOUT_AUTO_POS4.getPath(drive),
                 AutoPath.KNOCKOUT_AUTO_POS1.getPath(drive),
                 AutoPath.KNOCKOUT_AUTO_POS5.getPath(drive),
                 AutoPath.KNOCKOUT_AUTO_POS6.getPath(drive),
-                AutoPath.KNOCKOUT_AUTO_POS1.getPath(drive)
+                scoreCubeLow(),
+                parallel(stowArmCloseIntake(),
+                        AutoPath.KNOCKOUT_AUTO_POS1.getPath(drive))
 
         // AutoPath.LINE_AUTO_POS1.getPath(drive)
         );

--- a/src/main/java/frc/robot/Auto.java
+++ b/src/main/java/frc/robot/Auto.java
@@ -133,17 +133,19 @@ public class Auto {
     public CommandBase stowArmCloseIntake() {
         return sequence(
                 armExtend.moveTo(ArmPresets.ARM_STOWED),
-                intake.coneGrab(),
+                intake.closeIntake(),
                 armRotate.moveTo(ArmPresets.ARM_STOWED));
     }
 
     public CommandBase pickUpCube() {
         return sequence(
                 armRotate.moveTo(ArmPresets.CUBE_PICKUP),
-                armExtend.moveTo(ArmPresets.CUBE_PICKUP),
-                intake.grab(),
-                armExtend.retract(0.4),
-                armRotate.moveTo(ArmPresets.ARM_STOWED));
+                // armExtend.moveTo(ArmPresets.CUBE_PICKUP),
+                intake.openIntake(),
+                intake.grab()
+
+        // armExtend.retract(0.4),
+        );
     }
 
     public CommandBase scoreCube() {
@@ -151,7 +153,16 @@ public class Auto {
                 armRotate.moveTo(ArmPresets.HIGH_SCORE),
                 timingWait(),
                 intake.cubeRelease(),
-                timingWait());
+                timingWait(),
+                armRotate.moveTo(ArmPresets.ARM_STOWED));
+    }
+
+    public CommandBase scoreCubeLow() {
+        return sequence(
+                armRotate.moveTo(ArmPresets.CUBE_PICKUP),
+                parallel(intake.cubeRelease(),
+                        intake.closeIntake()),
+                armRotate.moveTo(ArmPresets.ARM_STOWED));
     }
 
     public CommandBase scoreHighNode() {
@@ -257,11 +268,13 @@ public class Auto {
 
                 AutoPath.KNOCKOUT_AUTO_POS1.getPath(drive),
                 AutoPath.KNOCKOUT_AUTO_POS2.getPath(drive),
-                AutoPath.KNOCKOUT_AUTO_POS3.getPath(drive),
+                parallel(AutoPath.KNOCKOUT_AUTO_POS3.getPath(drive),
+                        pickUpCube()),
                 AutoPath.KNOCKOUT_AUTO_POS4.getPath(drive),
                 AutoPath.KNOCKOUT_AUTO_POS1.getPath(drive),
                 AutoPath.KNOCKOUT_AUTO_POS5.getPath(drive),
                 AutoPath.KNOCKOUT_AUTO_POS6.getPath(drive),
+                scoreCubeLow(),
                 AutoPath.KNOCKOUT_AUTO_POS1.getPath(drive)
 
         // AutoPath.LINE_AUTO_POS1.getPath(drive)
@@ -278,7 +291,7 @@ public class Auto {
                 AutoPath.TRIANGLE_AUTO_POS3.getPath(drive),
                 // waitSeconds(1.5),
                 AutoPath.TRIANGLE_AUTO_POS1.getPath(drive));
->>>>>>> Stashed changes
+
     }
 
     // Square auto using driveRaw Command maybe?

--- a/src/main/java/frc/robot/Auto.java
+++ b/src/main/java/frc/robot/Auto.java
@@ -144,15 +144,6 @@ public class Auto {
                 armRotate.moveTo(ArmPresets.ARM_STOWED));
     }
 
-    public CommandBase pickUpCone() {
-        return sequence(
-                armRotate.moveTo(ArmPresets.CONE_PICKUP),
-                armExtend.moveTo(ArmPresets.CONE_PICKUP),
-                intake.grab().raceWith(drive.driveRelative(new Translation2d(0, -0.5), 270, 2)),
-                armExtend.retract(0.4),
-                armRotate.moveTo(ArmPresets.ARM_STOWED));
-    }
-
     public CommandBase scoreCube() {
         return sequence(
                 armRotate.moveTo(ArmPresets.HIGH_SCORE),
@@ -216,7 +207,8 @@ public class Auto {
                 conePos.communityPosition.inCommunity.getPath(drive),
                 scoreCubeCmd,
                 scoreCube()
-        // position to be in front of drive station in community? I'll add that
+        // position to be in front of drive station in community? I'll add that <- ha
+        // you thought, no becuase this auto is useless
         // , drive.driveUntilTipped()
         // , drive.balance()
 
@@ -225,6 +217,35 @@ public class Auto {
 
     private CommandBase timingWait() {
         return new FunctionalWaitCommand(() -> 0.25);
+    }
+
+    // Square auto using the drive relative command
+    public CommandBase squareAutoDriveRelative() {
+        return sequence(
+                drive.setGyro180(),
+                drive.driveRelative(new Translation2d(0, 0), 0, 3),
+                drive.driveRelative(new Translation2d(0, 0), 90, 3),
+                drive.driveRelative(new Translation2d(0, 0), 180, 3),
+                drive.driveRelative(new Translation2d(0, 0), 270, 3),
+                drive.driveRelative(new Translation2d(0, 0), 0, 3));
+    }
+
+    // Square auto using pathing
+    public CommandBase squareAutoPathing() {
+        return sequence(
+                AutoPath.SQUARE_AUTO_POS1.getPath(drive),
+                AutoPath.SQUARE_AUTO_POS2.getPath(drive),
+                AutoPath.SQUARE_AUTO_POS3.getPath(drive),
+                AutoPath.SQUARE_AUTO_POS4.getPath(drive),
+                AutoPath.SQUARE_AUTO_POS1.getPath(drive)
+        );
+    }
+
+    // Square auto using driveRaw Command maybe?
+    public CommandBase squareAutoMoveTurn() {
+        return sequence(
+
+        );
     }
 
 }

--- a/src/main/java/frc/robot/Auto.java
+++ b/src/main/java/frc/robot/Auto.java
@@ -148,6 +148,14 @@ public class Auto {
         );
     }
 
+    public CommandBase scoreCubeLow() {
+        return sequence(
+                armRotate.moveTo(ArmPresets.CUBE_PICKUP),
+                parallel(intake.cubeRelease(),
+                        intake.closeIntake()),
+                armRotate.moveTo(ArmPresets.ARM_STOWED));
+    }
+
     public CommandBase scoreCube() {
         return sequence(
                 armRotate.moveTo(ArmPresets.HIGH_SCORE),
@@ -157,13 +165,13 @@ public class Auto {
                 armRotate.moveTo(ArmPresets.ARM_STOWED));
     }
 
-    public CommandBase scoreCubeLow() {
-        return sequence(
-                armRotate.moveTo(ArmPresets.CUBE_PICKUP),
-                parallel(intake.cubeRelease(),
-                        intake.closeIntake()),
-                armRotate.moveTo(ArmPresets.ARM_STOWED));
-    }
+    // public CommandBase scoreCubeL() {
+    // return sequence(
+    // armRotate.moveTo(ArmPresets.CUBE_PICKUP),
+    // parallel(intake.cubeRelease(),
+    // intake.closeIntake()),
+    // armRotate.moveTo(ArmPresets.ARM_STOWED));
+    // }
 
     public CommandBase scoreHighNode() {
         return sequence(
@@ -268,11 +276,15 @@ public class Auto {
 
                 AutoPath.KNOCKOUT_AUTO_POS1.getPath(drive),
                 AutoPath.KNOCKOUT_AUTO_POS2.getPath(drive),
-                AutoPath.KNOCKOUT_AUTO_POS3.getPath(drive),
+                parallel(
+                        AutoPath.KNOCKOUT_AUTO_POS3.getPath(drive), pickUpCube()),
                 AutoPath.KNOCKOUT_AUTO_POS4.getPath(drive),
                 AutoPath.KNOCKOUT_AUTO_POS1.getPath(drive),
                 AutoPath.KNOCKOUT_AUTO_POS5.getPath(drive),
                 AutoPath.KNOCKOUT_AUTO_POS6.getPath(drive),
+                sequence(intake.cubeRelease(),
+                        intake.closeIntake()),
+                // scoreCubeLow(),
                 AutoPath.KNOCKOUT_AUTO_POS1.getPath(drive)
 
         // AutoPath.LINE_AUTO_POS1.getPath(drive)

--- a/src/main/java/frc/robot/Auto.java
+++ b/src/main/java/frc/robot/Auto.java
@@ -268,14 +268,12 @@ public class Auto {
 
                 AutoPath.KNOCKOUT_AUTO_POS1.getPath(drive),
                 AutoPath.KNOCKOUT_AUTO_POS2.getPath(drive),
-                parallel(AutoPath.KNOCKOUT_AUTO_POS3.getPath(drive), pickUpCube()),
+                AutoPath.KNOCKOUT_AUTO_POS3.getPath(drive),
                 AutoPath.KNOCKOUT_AUTO_POS4.getPath(drive),
                 AutoPath.KNOCKOUT_AUTO_POS1.getPath(drive),
                 AutoPath.KNOCKOUT_AUTO_POS5.getPath(drive),
                 AutoPath.KNOCKOUT_AUTO_POS6.getPath(drive),
-                scoreCubeLow(),
-                parallel(stowArmCloseIntake(),
-                        AutoPath.KNOCKOUT_AUTO_POS1.getPath(drive))
+                AutoPath.KNOCKOUT_AUTO_POS1.getPath(drive)
 
         // AutoPath.LINE_AUTO_POS1.getPath(drive)
         );

--- a/src/main/java/frc/robot/Auto.java
+++ b/src/main/java/frc/robot/Auto.java
@@ -268,15 +268,12 @@ public class Auto {
 
                 AutoPath.KNOCKOUT_AUTO_POS1.getPath(drive),
                 AutoPath.KNOCKOUT_AUTO_POS2.getPath(drive),
-                parallel(AutoPath.KNOCKOUT_AUTO_POS3.getPath(drive),
-                        pickUpCube()),
+                AutoPath.KNOCKOUT_AUTO_POS3.getPath(drive),
                 AutoPath.KNOCKOUT_AUTO_POS4.getPath(drive),
                 AutoPath.KNOCKOUT_AUTO_POS1.getPath(drive),
                 AutoPath.KNOCKOUT_AUTO_POS5.getPath(drive),
                 AutoPath.KNOCKOUT_AUTO_POS6.getPath(drive),
-                scoreCubeLow(),
-                parallel(stowArmCloseIntake(),
-                        AutoPath.KNOCKOUT_AUTO_POS1.getPath(drive))
+                AutoPath.KNOCKOUT_AUTO_POS1.getPath(drive)
 
         // AutoPath.LINE_AUTO_POS1.getPath(drive)
         );
@@ -292,16 +289,6 @@ public class Auto {
                 AutoPath.TRIANGLE_AUTO_POS3.getPath(drive),
                 // waitSeconds(1.5),
                 AutoPath.TRIANGLE_AUTO_POS1.getPath(drive));
-
-    }
-
-    // Testing with a rectangle (Liam)
-    public CommandBase rectangleAutoPathing() {
-        return sequence(
-                AutoPath.RECTANGLE_AUTO_POS1.getPath(drive),
-                AutoPath.RECTANGLE_AUTO_POS2.getPath(drive),
-                AutoPath.RECTANGLE_AUTO_POS3.getPath(drive),
-                AutoPath.RECTANGLE_AUTO_POS4.getPath(drive));
     }
 
     // Square auto using driveRaw Command maybe?

--- a/src/main/java/frc/robot/Auto.java
+++ b/src/main/java/frc/robot/Auto.java
@@ -275,7 +275,8 @@ public class Auto {
                 AutoPath.KNOCKOUT_AUTO_POS5.getPath(drive),
                 AutoPath.KNOCKOUT_AUTO_POS6.getPath(drive),
                 scoreCubeLow(),
-                AutoPath.KNOCKOUT_AUTO_POS1.getPath(drive)
+                parallel(stowArmCloseIntake(),
+                        AutoPath.KNOCKOUT_AUTO_POS1.getPath(drive))
 
         // AutoPath.LINE_AUTO_POS1.getPath(drive)
         );

--- a/src/main/java/frc/robot/Auto.java
+++ b/src/main/java/frc/robot/Auto.java
@@ -9,6 +9,7 @@ import static edu.wpi.first.wpilibj2.command.Commands.waitSeconds;
 
 import com.chopshop166.chopshoplib.commands.FunctionalWaitCommand;
 
+import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.util.Units;
@@ -16,6 +17,7 @@ import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.networktables.StringSubscriber;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import edu.wpi.first.wpilibj2.command.ConditionalCommand;
+import frc.robot.auto.AutoConstants;
 import frc.robot.auto.AutoPath;
 import frc.robot.auto.ConeStation;
 import frc.robot.auto.CubePickupLocation;
@@ -220,6 +222,7 @@ public class Auto {
     }
 
     // Square auto using the drive relative command
+    // Note: Tranlsation 2d x,y represents distance in the x plane, y plane
     public CommandBase squareAutoDriveRelative() {
         return sequence(
                 drive.setGyro180(),
@@ -227,17 +230,53 @@ public class Auto {
                 drive.driveRelative(new Translation2d(0.0, 2.0), 0, 3),
                 drive.driveRelative(new Translation2d(-2.0, 2.0), 0, 3),
                 drive.driveRelative(new Translation2d(-2.0, 0), 0, 3),
-                drive.driveRelative(new Translation2d(0, 0), 0, 3));
+                drive.driveRelative(new Translation2d(0, 0), 0, 3)).withName("Square: ");
     }
 
     // Square auto using pathing
     public CommandBase squareAutoPathing() {
         return sequence(
                 AutoPath.SQUARE_AUTO_POS1.getPath(drive),
+                // waitSeconds(1.5),
                 AutoPath.SQUARE_AUTO_POS2.getPath(drive),
+                // waitSeconds(1.5),
                 AutoPath.SQUARE_AUTO_POS3.getPath(drive),
+                // waitSeconds(1.5),
                 AutoPath.SQUARE_AUTO_POS4.getPath(drive),
-                AutoPath.SQUARE_AUTO_POS1.getPath(drive));
+                // waitSeconds(1.5),
+                AutoPath.SQUARE_AUTO_POS1.getPath(drive)).withName("Square: (Pathing)");
+    }
+
+    // Line Auto
+    public CommandBase knockoutAutoPathing() {
+        return sequence(
+                // Vision.setPose(Pose2d(0.0, 0.0, AutoConstants.ROTATION_0)),
+
+                drive.setPose(new Pose2d(0.0, 0.0,
+                        AutoConstants.ROTATION_0)),
+                AutoPath.KNOCKOUT_AUTO_POS1.getPath(drive),
+                AutoPath.KNOCKOUT_AUTO_POS2.getPath(drive),
+                AutoPath.KNOCKOUT_AUTO_POS3.getPath(drive),
+                AutoPath.KNOCKOUT_AUTO_POS4.getPath(drive),
+                AutoPath.KNOCKOUT_AUTO_POS1.getPath(drive),
+                AutoPath.KNOCKOUT_AUTO_POS5.getPath(drive),
+                AutoPath.KNOCKOUT_AUTO_POS6.getPath(drive),
+                AutoPath.KNOCKOUT_AUTO_POS1.getPath(drive)
+
+        // AutoPath.LINE_AUTO_POS1.getPath(drive)
+        );
+    }
+
+    // Triangle Auto
+    public CommandBase triangleAutoPathing() {
+        return sequence(
+                AutoPath.TRIANGLE_AUTO_POS1.getPath(drive),
+                // waitSeconds(1.5),
+                AutoPath.TRIANGLE_AUTO_POS2.getPath(drive),
+                // waitSeconds(1.5),
+                AutoPath.TRIANGLE_AUTO_POS3.getPath(drive),
+                // waitSeconds(1.5),
+                AutoPath.TRIANGLE_AUTO_POS1.getPath(drive));
     }
 
     // Square auto using driveRaw Command maybe?
@@ -247,4 +286,7 @@ public class Auto {
         );
     }
 
+    public void resetCoords() {
+        // no clue how to do this
+    }
 }

--- a/src/main/java/frc/robot/Auto.java
+++ b/src/main/java/frc/robot/Auto.java
@@ -252,8 +252,9 @@ public class Auto {
         return sequence(
                 // Vision.setPose(Pose2d(0.0, 0.0, AutoConstants.ROTATION_0)),
 
-                drive.setPose(new Pose2d(0.0, 0.0,
-                        AutoConstants.ROTATION_0)),
+                // drive.setPose(new Pose2d(0.0, 0.0,
+                // AutoConstants.ROTATION_0)),
+
                 AutoPath.KNOCKOUT_AUTO_POS1.getPath(drive),
                 AutoPath.KNOCKOUT_AUTO_POS2.getPath(drive),
                 AutoPath.KNOCKOUT_AUTO_POS3.getPath(drive),
@@ -277,6 +278,7 @@ public class Auto {
                 AutoPath.TRIANGLE_AUTO_POS3.getPath(drive),
                 // waitSeconds(1.5),
                 AutoPath.TRIANGLE_AUTO_POS1.getPath(drive));
+>>>>>>> Stashed changes
     }
 
     // Square auto using driveRaw Command maybe?

--- a/src/main/java/frc/robot/Auto.java
+++ b/src/main/java/frc/robot/Auto.java
@@ -294,6 +294,15 @@ public class Auto {
 
     }
 
+    // Testing with a rectangle (Liam)
+    public CommandBase rectangleAutoPathing() {
+        return sequence(
+                AutoPath.RECTANGLE_AUTO_POS1.getPath(drive),
+                AutoPath.RECTANGLE_AUTO_POS2.getPath(drive),
+                AutoPath.RECTANGLE_AUTO_POS3.getPath(drive),
+                AutoPath.RECTANGLE_AUTO_POS4.getPath(drive));
+    }
+
     // Square auto using driveRaw Command maybe?
     public CommandBase squareAutoMoveTurn() {
         return sequence(

--- a/src/main/java/frc/robot/Auto.java
+++ b/src/main/java/frc/robot/Auto.java
@@ -208,7 +208,7 @@ public class Auto {
                 scoreCubeCmd,
                 scoreCube()
         // position to be in front of drive station in community? I'll add that <- ha
-        // you thought, no becuase this auto is useless
+        // you thought, no because this auto is useless
         // , drive.driveUntilTipped()
         // , drive.balance()
 
@@ -223,10 +223,10 @@ public class Auto {
     public CommandBase squareAutoDriveRelative() {
         return sequence(
                 drive.setGyro180(),
-                drive.driveRelative(new Translation2d(0, 0), 0, 3),
-                drive.driveRelative(new Translation2d(0, 0), 90, 3),
-                drive.driveRelative(new Translation2d(0, 0), 180, 3),
-                drive.driveRelative(new Translation2d(0, 0), 270, 3),
+                drive.driveRelative(new Translation2d(0.0, 0.0), 0, 3),
+                drive.driveRelative(new Translation2d(0.0, 2.0), 0, 3),
+                drive.driveRelative(new Translation2d(-2.0, 2.0), 0, 3),
+                drive.driveRelative(new Translation2d(-2.0, 0), 0, 3),
                 drive.driveRelative(new Translation2d(0, 0), 0, 3));
     }
 
@@ -237,8 +237,7 @@ public class Auto {
                 AutoPath.SQUARE_AUTO_POS2.getPath(drive),
                 AutoPath.SQUARE_AUTO_POS3.getPath(drive),
                 AutoPath.SQUARE_AUTO_POS4.getPath(drive),
-                AutoPath.SQUARE_AUTO_POS1.getPath(drive)
-        );
+                AutoPath.SQUARE_AUTO_POS1.getPath(drive));
     }
 
     // Square auto using driveRaw Command maybe?

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -10,6 +10,7 @@ import com.chopshop166.chopshoplib.RobotUtils;
 import com.chopshop166.chopshoplib.commands.CommandRobot;
 import com.chopshop166.chopshoplib.controls.ButtonXboxController;
 
+import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.trajectory.TrapezoidProfile.Constraints;
 import edu.wpi.first.networktables.NetworkTableInstance;
@@ -26,6 +27,7 @@ import edu.wpi.first.wpilibj2.command.CommandBase;
 import edu.wpi.first.wpilibj2.command.ConditionalCommand;
 import edu.wpi.first.wpilibj2.command.ProxyCommand;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
+import frc.robot.auto.AutoConstants;
 import frc.robot.auto.ConeStation;
 import frc.robot.auto.CubePickupLocation;
 import frc.robot.maps.RobotMap;
@@ -221,12 +223,20 @@ public class Robot extends CommandRobot {
         driveController.rightStick().whileTrue(drive.robotCentricDrive(driveController::getLeftX,
                 driveController::getLeftY, driveController::getRightX));
 
-        driveController.y().whileTrue(drive.balance());
-        driveController.x().whileTrue(drive.rotateToAngle(Rotation2d.fromDegrees(180), () -> 0, () -> 0));
-        driveController.a().whileTrue(drive.rotateToAngle(Rotation2d.fromDegrees(0), () -> 0, () -> 0));
+        // driveController.y().whileTrue(drive.balance());
+        // driveController.x().whileTrue(drive.rotateToAngle(Rotation2d.fromDegrees(180),
+        // () -> 0, () -> 0));
+        // driveController.a().whileTrue(drive.rotateToAngle(Rotation2d.fromDegrees(0),
+        // () -> 0, () -> 0));
 
         (new Trigger(() -> driveController.getRightTriggerAxis() > 0.5))
                 .onTrue(balanceArm.pushDown()).onFalse(balanceArm.pushUp());
+
+        driveController.a().whileTrue(auto.triangleAutoPathing());
+        driveController.x().whileTrue(auto.squareAutoPathing());
+        driveController.y().whileTrue(auto.knockoutAutoPathing());
+        driveController.b().onTrue(drive.setPose(new Pose2d(0.0, 0.0, AutoConstants.ROTATION_0)));
+
         // Arm
 
         // COPILOT CONTROLLER

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -12,6 +12,7 @@ import com.chopshop166.chopshoplib.controls.ButtonXboxController;
 
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.kinematics.SwerveDriveOdometry;
 import edu.wpi.first.math.trajectory.TrapezoidProfile.Constraints;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.networktables.StringPublisher;
@@ -231,12 +232,17 @@ public class Robot extends CommandRobot {
 
         (new Trigger(() -> driveController.getRightTriggerAxis() > 0.5))
                 .onTrue(balanceArm.pushDown()).onFalse(balanceArm.pushUp());
+<<<<<<< Updated upstream
+=======
 
         driveController.a().whileTrue(auto.triangleAutoPathing());
         driveController.x().whileTrue(auto.squareAutoPathing());
         driveController.y().whileTrue(auto.knockoutAutoPathing());
-        driveController.b().onTrue(drive.setPose(new Pose2d(0.0, 0.0, AutoConstants.ROTATION_0)));
+        // driveController.b().onTrue(drive.setPose(new Pose2d(0.0, 0.0,
+        // AutoConstants.ROTATION_0)));
+        // driveController.b().onTrue(Vision.setPose(new Pose2d(0.0, 0.0, 0.0)));
 
+>>>>>>> Stashed changes
         // Arm
 
         // COPILOT CONTROLLER

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -149,7 +149,7 @@ public class Robot extends CommandRobot {
 
     public CommandBase stowArm = sequence(
             led.setOrange(),
-            intake.coneGrab(),
+            intake.closeIntake(),
             armExtend.retract(0.4),
             armRotate.moveTo(ArmPresets.ARM_STOWED),
             led.colorAlliance());
@@ -161,7 +161,7 @@ public class Robot extends CommandRobot {
                     sequence(
                             armRotate.moveTo(ArmPresets.CUBE_PICKUP), armExtend.moveTo(
                                     ArmPresets.CUBE_PICKUP),
-                            intake.coneRelease()),
+                            intake.openIntake()),
                     () -> {
                         return gamePieceSub.get() == "Cone";
                     }));
@@ -232,8 +232,6 @@ public class Robot extends CommandRobot {
 
         (new Trigger(() -> driveController.getRightTriggerAxis() > 0.5))
                 .onTrue(balanceArm.pushDown()).onFalse(balanceArm.pushUp());
-<<<<<<< Updated upstream
-=======
 
         driveController.a().whileTrue(auto.triangleAutoPathing());
         driveController.x().whileTrue(auto.squareAutoPathing());
@@ -242,7 +240,6 @@ public class Robot extends CommandRobot {
         // AutoConstants.ROTATION_0)));
         // driveController.b().onTrue(Vision.setPose(new Pose2d(0.0, 0.0, 0.0)));
 
->>>>>>> Stashed changes
         // Arm
 
         // COPILOT CONTROLLER

--- a/src/main/java/frc/robot/auto/AutoConstants.java
+++ b/src/main/java/frc/robot/auto/AutoConstants.java
@@ -8,7 +8,9 @@ public class AutoConstants {
 
     // public static final double BLUE_X = 1.8;
     public static final Rotation2d ROTATION_0 = Rotation2d.fromDegrees(0);
+    public static final Rotation2d ROTATION_90 = Rotation2d.fromDegrees(90);
     public static final Rotation2d ROTATION_180 = Rotation2d.fromDegrees(180);
+    public static final Rotation2d ROTATION_270 = Rotation2d.fromDegrees(270);
 
     public static final double UP_TO_CONE_X = 1.78;
     public static final double BACKED_UP_X = 2.25;

--- a/src/main/java/frc/robot/auto/AutoPath.java
+++ b/src/main/java/frc/robot/auto/AutoPath.java
@@ -151,33 +151,23 @@ public enum AutoPath {
     SQUARE_AUTO_POS4(0.2, new Pose2d(1.0, 0.0, AutoConstants.ROTATION_0)),
     // Go right 2 meters (x axis)
 
-    SQUARE_AUTO_POS5(0.2, new Pose2d(2.0, 0, AutoConstants.ROTATION_0)),
-
     KNOCKOUT_AUTO_POS1(0.2, new Pose2d(0.0, 0.0, AutoConstants.ROTATION_0)),
 
     KNOCKOUT_AUTO_POS2(0.2, new Pose2d(4.3, 0.0, AutoConstants.ROTATION_270)),
 
-    KNOCKOUT_AUTO_POS3(0.2, new Pose2d(4.3, -2.2, AutoConstants.ROTATION_270)),
+    KNOCKOUT_AUTO_POS3(0.2, new Pose2d(4.3, -2.7, AutoConstants.ROTATION_270)),
 
-    KNOCKOUT_AUTO_POS4(0.2, new Pose2d(4.3, -1.6, AutoConstants.ROTATION_270)),
+    KNOCKOUT_AUTO_POS4(0.2, new Pose2d(4.3, -2.0, AutoConstants.ROTATION_270)),
 
-    KNOCKOUT_AUTO_POS5(0.2, new Pose2d(2.6, 0.0, AutoConstants.ROTATION_0)),
+    KNOCKOUT_AUTO_POS5(0.2, new Pose2d(3.6, 0.0, AutoConstants.ROTATION_0)),
 
-    KNOCKOUT_AUTO_POS6(0.2, new Pose2d(2.6, -2.2, AutoConstants.ROTATION_270)),
+    KNOCKOUT_AUTO_POS6(0.2, new Pose2d(3.6, -2.7, AutoConstants.ROTATION_270)),
 
     TRIANGLE_AUTO_POS1(0.2, new Pose2d(0.0, 0.0, AutoConstants.ROTATION_0)),
 
     TRIANGLE_AUTO_POS2(0.2, new Pose2d(0.0, 1.5, AutoConstants.ROTATION_0)),
 
     TRIANGLE_AUTO_POS3(0.2, new Pose2d(1.5, 0.75, AutoConstants.ROTATION_0)),
-
-    RECTANGLE_AUTO_POS1(0.2, new Pose2d(0.0, 0.0, AutoConstants.ROTATION_0)),
-
-    RECTANGLE_AUTO_POS2(0.2, new Pose2d(0.0, 1.0, AutoConstants.ROTATION_0)),
-
-    RECTANGLE_AUTO_POS3(0.2, new Pose2d(2.0, 1.0, AutoConstants.ROTATION_180)),
-
-    RECTANGLE_AUTO_POS4(0.2, new Pose2d(2.0, 0.0, AutoConstants.ROTATION_180)),
 
     //// Start of some stuff that Joe wrote
     PRE_TEST(0.05,

--- a/src/main/java/frc/robot/auto/AutoPath.java
+++ b/src/main/java/frc/robot/auto/AutoPath.java
@@ -155,13 +155,13 @@ public enum AutoPath {
 
     KNOCKOUT_AUTO_POS2(0.2, new Pose2d(4.3, 0.0, AutoConstants.ROTATION_270)),
 
-    KNOCKOUT_AUTO_POS3(0.2, new Pose2d(4.3, -2.2, AutoConstants.ROTATION_270)),
+    KNOCKOUT_AUTO_POS3(0.2, new Pose2d(4.3, -2.7, AutoConstants.ROTATION_270)),
 
-    KNOCKOUT_AUTO_POS4(0.2, new Pose2d(4.3, -1.6, AutoConstants.ROTATION_270)),
+    KNOCKOUT_AUTO_POS4(0.2, new Pose2d(4.3, -2.0, AutoConstants.ROTATION_270)),
 
-    KNOCKOUT_AUTO_POS5(0.2, new Pose2d(2.6, 0.0, AutoConstants.ROTATION_0)),
+    KNOCKOUT_AUTO_POS5(0.2, new Pose2d(3.6, 0.0, AutoConstants.ROTATION_0)),
 
-    KNOCKOUT_AUTO_POS6(0.2, new Pose2d(2.6, -2.2, AutoConstants.ROTATION_270)),
+    KNOCKOUT_AUTO_POS6(0.2, new Pose2d(3.6, -2.7, AutoConstants.ROTATION_270)),
 
     TRIANGLE_AUTO_POS1(0.2, new Pose2d(0.0, 0.0, AutoConstants.ROTATION_0)),
 

--- a/src/main/java/frc/robot/auto/AutoPath.java
+++ b/src/main/java/frc/robot/auto/AutoPath.java
@@ -155,13 +155,13 @@ public enum AutoPath {
 
     KNOCKOUT_AUTO_POS2(0.2, new Pose2d(4.3, 0.0, AutoConstants.ROTATION_270)),
 
-    KNOCKOUT_AUTO_POS3(0.2, new Pose2d(4.3, -2.7, AutoConstants.ROTATION_270)),
+    KNOCKOUT_AUTO_POS3(0.2, new Pose2d(4.3, -2.2, AutoConstants.ROTATION_270)),
 
     KNOCKOUT_AUTO_POS4(0.2, new Pose2d(4.3, -2.0, AutoConstants.ROTATION_270)),
 
-    KNOCKOUT_AUTO_POS5(0.2, new Pose2d(3.6, 0.0, AutoConstants.ROTATION_0)),
+    KNOCKOUT_AUTO_POS5(0.2, new Pose2d(2.6, 0.0, AutoConstants.ROTATION_0)),
 
-    KNOCKOUT_AUTO_POS6(0.2, new Pose2d(3.6, -2.7, AutoConstants.ROTATION_270)),
+    KNOCKOUT_AUTO_POS6(0.2, new Pose2d(2.6, -2.2, AutoConstants.ROTATION_270)),
 
     TRIANGLE_AUTO_POS1(0.2, new Pose2d(0.0, 0.0, AutoConstants.ROTATION_0)),
 

--- a/src/main/java/frc/robot/auto/AutoPath.java
+++ b/src/main/java/frc/robot/auto/AutoPath.java
@@ -141,16 +141,33 @@ public enum AutoPath {
             new Pose2d()),
 
     //// Square Auto Pathing
-    // Starting position, moving nowhere (is this necessary?)
-    SQUARE_AUTO_POS1(0.2, new Pose2d(0, 0, AutoConstants.ROTATION_0)),
+    // No clue if this is coordinates or distance or a mix? I'm confused
+    SQUARE_AUTO_POS1(0.2, new Pose2d(0.0, 0.0, AutoConstants.ROTATION_0)),
     // Go up 2 meters (y axis)
-    SQUARE_AUTO_POS2(0.2, new Pose2d(0, 2.0, AutoConstants.ROTATION_0)),
+    SQUARE_AUTO_POS2(0.2, new Pose2d(0.0, 1.0, AutoConstants.ROTATION_0)),
     // Go left 2 meters (x axis)
-    SQUARE_AUTO_POS3(0.2, new Pose2d(-2.0, 0, AutoConstants.ROTATION_0)),
+    SQUARE_AUTO_POS3(0.2, new Pose2d(1.0, 1.0, AutoConstants.ROTATION_0)),
     // Go down 2 meters (y axis)
-    SQUARE_AUTO_POS4(0.2, new Pose2d(0, -2.0, AutoConstants.ROTATION_0)),
+    SQUARE_AUTO_POS4(0.2, new Pose2d(1.0, 0.0, AutoConstants.ROTATION_0)),
     // Go right 2 meters (x axis)
-    SQUARE_AUTO_POS5(0.2, new Pose2d(2.0, 0, AutoConstants.ROTATION_0)),
+
+    KNOCKOUT_AUTO_POS1(0.2, new Pose2d(0.0, 0.0, AutoConstants.ROTATION_0)),
+
+    KNOCKOUT_AUTO_POS2(0.2, new Pose2d(4.3, 0.0, AutoConstants.ROTATION_0)),
+
+    KNOCKOUT_AUTO_POS3(0.2, new Pose2d(4.3, -2.7, AutoConstants.ROTATION_270)),
+
+    KNOCKOUT_AUTO_POS4(0.2, new Pose2d(4.3, -2.0, AutoConstants.ROTATION_270)),
+
+    KNOCKOUT_AUTO_POS5(0.2, new Pose2d(3.6, 0.0, AutoConstants.ROTATION_0)),
+
+    KNOCKOUT_AUTO_POS6(0.2, new Pose2d(3.6, -2.7, AutoConstants.ROTATION_270)),
+
+    TRIANGLE_AUTO_POS1(0.2, new Pose2d(0.0, 0.0, AutoConstants.ROTATION_0)),
+
+    TRIANGLE_AUTO_POS2(0.2, new Pose2d(0.0, 1.5, AutoConstants.ROTATION_0)),
+
+    TRIANGLE_AUTO_POS3(0.2, new Pose2d(1.5, 0.75, AutoConstants.ROTATION_0)),
 
     //// Start of some stuff that Joe wrote
     PRE_TEST(0.05,

--- a/src/main/java/frc/robot/auto/AutoPath.java
+++ b/src/main/java/frc/robot/auto/AutoPath.java
@@ -155,13 +155,13 @@ public enum AutoPath {
 
     KNOCKOUT_AUTO_POS2(0.2, new Pose2d(4.3, 0.0, AutoConstants.ROTATION_270)),
 
-    KNOCKOUT_AUTO_POS3(0.2, new Pose2d(4.3, -2.7, AutoConstants.ROTATION_270)),
+    KNOCKOUT_AUTO_POS3(0.2, new Pose2d(4.3, -2.2, AutoConstants.ROTATION_270)),
 
-    KNOCKOUT_AUTO_POS4(0.2, new Pose2d(4.3, -2.0, AutoConstants.ROTATION_270)),
+    KNOCKOUT_AUTO_POS4(0.2, new Pose2d(4.3, -1.6, AutoConstants.ROTATION_270)),
 
-    KNOCKOUT_AUTO_POS5(0.2, new Pose2d(3.6, 0.0, AutoConstants.ROTATION_0)),
+    KNOCKOUT_AUTO_POS5(0.2, new Pose2d(2.6, 0.0, AutoConstants.ROTATION_0)),
 
-    KNOCKOUT_AUTO_POS6(0.2, new Pose2d(3.6, -2.7, AutoConstants.ROTATION_270)),
+    KNOCKOUT_AUTO_POS6(0.2, new Pose2d(2.6, -2.2, AutoConstants.ROTATION_270)),
 
     TRIANGLE_AUTO_POS1(0.2, new Pose2d(0.0, 0.0, AutoConstants.ROTATION_0)),
 

--- a/src/main/java/frc/robot/auto/AutoPath.java
+++ b/src/main/java/frc/robot/auto/AutoPath.java
@@ -150,28 +150,26 @@ public enum AutoPath {
     // Go down 2 meters (y axis)
     SQUARE_AUTO_POS4(0.2, new Pose2d(1.0, 0.0, AutoConstants.ROTATION_0)),
     // Go right 2 meters (x axis)
-<<<<<<< Updated upstream
+
     SQUARE_AUTO_POS5(0.2, new Pose2d(2.0, 0, AutoConstants.ROTATION_0)),
-=======
 
     KNOCKOUT_AUTO_POS1(0.2, new Pose2d(0.0, 0.0, AutoConstants.ROTATION_0)),
 
     KNOCKOUT_AUTO_POS2(0.2, new Pose2d(4.3, 0.0, AutoConstants.ROTATION_270)),
 
-    KNOCKOUT_AUTO_POS3(0.2, new Pose2d(4.3, -2.7, AutoConstants.ROTATION_270)),
+    KNOCKOUT_AUTO_POS3(0.2, new Pose2d(4.3, -2.2, AutoConstants.ROTATION_270)),
 
-    KNOCKOUT_AUTO_POS4(0.2, new Pose2d(4.3, -2.0, AutoConstants.ROTATION_270)),
+    KNOCKOUT_AUTO_POS4(0.2, new Pose2d(4.3, -1.6, AutoConstants.ROTATION_270)),
 
-    KNOCKOUT_AUTO_POS5(0.2, new Pose2d(3.6, 0.0, AutoConstants.ROTATION_0)),
+    KNOCKOUT_AUTO_POS5(0.2, new Pose2d(2.6, 0.0, AutoConstants.ROTATION_0)),
 
-    KNOCKOUT_AUTO_POS6(0.2, new Pose2d(3.6, -2.7, AutoConstants.ROTATION_270)),
+    KNOCKOUT_AUTO_POS6(0.2, new Pose2d(2.6, -2.2, AutoConstants.ROTATION_270)),
 
     TRIANGLE_AUTO_POS1(0.2, new Pose2d(0.0, 0.0, AutoConstants.ROTATION_0)),
 
     TRIANGLE_AUTO_POS2(0.2, new Pose2d(0.0, 1.5, AutoConstants.ROTATION_0)),
 
     TRIANGLE_AUTO_POS3(0.2, new Pose2d(1.5, 0.75, AutoConstants.ROTATION_0)),
->>>>>>> Stashed changes
 
     //// Start of some stuff that Joe wrote
     PRE_TEST(0.05,

--- a/src/main/java/frc/robot/auto/AutoPath.java
+++ b/src/main/java/frc/robot/auto/AutoPath.java
@@ -140,6 +140,15 @@ public enum AutoPath {
     OUTER_SIDE_CHARGE_STATION_15(0.2,
             new Pose2d()),
 
+    // Square Auto Pathing
+    SQUARE_AUTO_POS1(0.2, new Pose2d(1.0, 1.0, AutoConstants.ROTATION_0)),
+
+    SQUARE_AUTO_POS2(0.2, new Pose2d(5.0, 1.0, AutoConstants.ROTATION_0)),
+
+    SQUARE_AUTO_POS3(0.2, new Pose2d(5.0, 5.0, AutoConstants.ROTATION_0)),
+
+    SQUARE_AUTO_POS4(0.2, new Pose2d(1.0, 5.0, AutoConstants.ROTATION_0)),
+
     //// Start of some stuff that Joe wrote
     PRE_TEST(0.05,
             new Pose2d(14.165401626124469, 2.879876924969839, Rotation2d.fromRadians(-0.22656457143950046)));

--- a/src/main/java/frc/robot/auto/AutoPath.java
+++ b/src/main/java/frc/robot/auto/AutoPath.java
@@ -150,10 +150,13 @@ public enum AutoPath {
     // Go down 2 meters (y axis)
     SQUARE_AUTO_POS4(0.2, new Pose2d(1.0, 0.0, AutoConstants.ROTATION_0)),
     // Go right 2 meters (x axis)
+<<<<<<< Updated upstream
+    SQUARE_AUTO_POS5(0.2, new Pose2d(2.0, 0, AutoConstants.ROTATION_0)),
+=======
 
     KNOCKOUT_AUTO_POS1(0.2, new Pose2d(0.0, 0.0, AutoConstants.ROTATION_0)),
 
-    KNOCKOUT_AUTO_POS2(0.2, new Pose2d(4.3, 0.0, AutoConstants.ROTATION_0)),
+    KNOCKOUT_AUTO_POS2(0.2, new Pose2d(4.3, 0.0, AutoConstants.ROTATION_270)),
 
     KNOCKOUT_AUTO_POS3(0.2, new Pose2d(4.3, -2.7, AutoConstants.ROTATION_270)),
 
@@ -168,6 +171,7 @@ public enum AutoPath {
     TRIANGLE_AUTO_POS2(0.2, new Pose2d(0.0, 1.5, AutoConstants.ROTATION_0)),
 
     TRIANGLE_AUTO_POS3(0.2, new Pose2d(1.5, 0.75, AutoConstants.ROTATION_0)),
+>>>>>>> Stashed changes
 
     //// Start of some stuff that Joe wrote
     PRE_TEST(0.05,

--- a/src/main/java/frc/robot/auto/AutoPath.java
+++ b/src/main/java/frc/robot/auto/AutoPath.java
@@ -140,14 +140,17 @@ public enum AutoPath {
     OUTER_SIDE_CHARGE_STATION_15(0.2,
             new Pose2d()),
 
-    // Square Auto Pathing
-    SQUARE_AUTO_POS1(0.2, new Pose2d(1.0, 1.0, AutoConstants.ROTATION_0)),
-
-    SQUARE_AUTO_POS2(0.2, new Pose2d(5.0, 1.0, AutoConstants.ROTATION_0)),
-
-    SQUARE_AUTO_POS3(0.2, new Pose2d(5.0, 5.0, AutoConstants.ROTATION_0)),
-
-    SQUARE_AUTO_POS4(0.2, new Pose2d(1.0, 5.0, AutoConstants.ROTATION_0)),
+    //// Square Auto Pathing
+    // Starting position, moving nowhere (is this necessary?)
+    SQUARE_AUTO_POS1(0.2, new Pose2d(0, 0, AutoConstants.ROTATION_0)),
+    // Go up 2 meters (y axis)
+    SQUARE_AUTO_POS2(0.2, new Pose2d(0, 2.0, AutoConstants.ROTATION_0)),
+    // Go left 2 meters (x axis)
+    SQUARE_AUTO_POS3(0.2, new Pose2d(-2.0, 0, AutoConstants.ROTATION_0)),
+    // Go down 2 meters (y axis)
+    SQUARE_AUTO_POS4(0.2, new Pose2d(0, -2.0, AutoConstants.ROTATION_0)),
+    // Go right 2 meters (x axis)
+    SQUARE_AUTO_POS5(0.2, new Pose2d(2.0, 0, AutoConstants.ROTATION_0)),
 
     //// Start of some stuff that Joe wrote
     PRE_TEST(0.05,

--- a/src/main/java/frc/robot/auto/AutoPath.java
+++ b/src/main/java/frc/robot/auto/AutoPath.java
@@ -171,6 +171,14 @@ public enum AutoPath {
 
     TRIANGLE_AUTO_POS3(0.2, new Pose2d(1.5, 0.75, AutoConstants.ROTATION_0)),
 
+    RECTANGLE_AUTO_POS1(0.2, new Pose2d(0.0, 0.0, AutoConstants.ROTATION_0)),
+
+    RECTANGLE_AUTO_POS2(0.2, new Pose2d(0.0, 1.0, AutoConstants.ROTATION_0)),
+
+    RECTANGLE_AUTO_POS3(0.2, new Pose2d(2.0, 1.0, AutoConstants.ROTATION_180)),
+
+    RECTANGLE_AUTO_POS4(0.2, new Pose2d(2.0, 0.0, AutoConstants.ROTATION_180)),
+
     //// Start of some stuff that Joe wrote
     PRE_TEST(0.05,
             new Pose2d(14.165401626124469, 2.879876924969839, Rotation2d.fromRadians(-0.22656457143950046)));

--- a/src/main/java/frc/robot/maps/FrostBiteMap.java
+++ b/src/main/java/frc/robot/maps/FrostBiteMap.java
@@ -177,7 +177,7 @@ public class FrostBiteMap extends RobotMap {
         absEncoder.setDutyCycleRange(1.0 / 1025.0, 1024.0 / 1025.0);
         absEncoder.setDistancePerRotation(-360);
         // Adjust this to move the encoder zero point to the retracted position
-        absEncoder.setPositionOffset(91.89780758483522 - 7);
+        absEncoder.setPositionOffset(54);
 
         CSFusedEncoder fusedEncoder = new CSFusedEncoder(encoder, absEncoder);
 

--- a/src/main/java/frc/robot/subsystems/Drive.java
+++ b/src/main/java/frc/robot/subsystems/Drive.java
@@ -13,7 +13,6 @@ import com.chopshop166.chopshoplib.RobotUtils;
 import com.chopshop166.chopshoplib.commands.FunctionalWaitCommand;
 import com.chopshop166.chopshoplib.commands.SmartSubsystemBase;
 
-import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Rotation3d;
@@ -312,6 +311,7 @@ public class Drive extends SmartSubsystemBase {
                                         .getTranslation().getDistance(pose.getTranslation())) {
                             closestPose = position.getPose();
                         }
+
                     }
 
                     return driveTo(closestPose, 0.05);
@@ -393,6 +393,12 @@ public class Drive extends SmartSubsystemBase {
 
         }).runsUntil(balancedCheck).onEnd(() -> Logger.getInstance().recordOutput("AutoBalanceState", "ended"));
 
+    }
+
+    public CommandBase moveForDirectional(double xSpeed, double ySpeed, double seconds) {
+        return race(
+                driveRaw(() -> xSpeed, () -> ySpeed, () -> 0),
+                new FunctionalWaitCommand(() -> seconds)).andThen(safeStateCmd());
     }
 
     public CommandBase resetGyroCommand() {

--- a/src/main/java/frc/robot/subsystems/Intake.java
+++ b/src/main/java/frc/robot/subsystems/Intake.java
@@ -37,21 +37,20 @@ public class Intake extends LoggedSubsystem<IntakeData, IntakeData.Map> {
         clawPub.set(getData().solenoidSetPoint == Value.kForward);
     }
 
-    // Grabs game piece Cone
-    public CommandBase coneGrab() {
-        return runOnce(() -> {
-            getData().solenoidSetPoint = Value.kForward;
-        });
-    }
-
     // Releases game piece Cone
-    public CommandBase coneRelease() {
+    public CommandBase openIntake() {
         return runOnce(() -> {
             getData().solenoidSetPoint = Value.kReverse;
         });
     }
 
-    // Releases game piece Cone
+    public CommandBase closeIntake() {
+        return runOnce(() -> {
+            getData().solenoidSetPoint = Value.kForward;
+        });
+    }
+
+    // Opens or closes intake
     public CommandBase toggle() {
         return runOnce(() -> {
             if (getData().solenoidSetPoint == Value.kForward) {


### PR DESCRIPTION
Created the drive-in-a-square auto using two methods: 
1. The drive relative function (we just need to plug in x and y values for speed but I don't entirely understand how it works) and 
2. Pathing (after creating new field points specifically for this) - though pathing didn't work last year so I'm not sure if it would work for this but I like the idea of trying to figure it out